### PR TITLE
Fix bug with lat() and lng() not returned

### DIFF
--- a/src/vs-google-autocomplete.js
+++ b/src/vs-google-autocomplete.js
@@ -92,15 +92,20 @@ angular.module('vsGoogleAutocomplete').factory('vsGooglePlaceUtility', function(
     }
 
     function getLatitude(place) {
-        if (!isGeometryExist(place)) return;
-        return place.geometry.location.lat();
+        if (!isGeometryExist(place)) {
+            return;
+        } else {
+            return place.geometry.location.lat();
+        }
     }
 
     function getLongitude(place) {
-        if (!isGeometryExist(place)) return;
-        return place.geometry.location.lng();
+        if (!isGeometryExist(place)){
+            return;
+        } else {
+            return place.geometry.location.lng();
+        }
     }
-
 	return {
 	    isGooglePlace: isGooglePlace,
         isContainTypes: isContainTypes,


### PR DESCRIPTION
As of https://github.com/vskosp/vsGoogleAutocomplete/issues/9. Now lat and lng return correctly
